### PR TITLE
Fixes widget.json to have right spec version

### DIFF
--- a/widgets/Stream-streamingsource.json
+++ b/widgets/Stream-streamingsource.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "spec-version": "1.0"
+    "spec-version": "1.3"
   },
   "configuration-groups": [
     {


### PR DESCRIPTION
- Right now the spec version for widget.json is incorrect.
- It needs to be `1.3` to be able to pick up show "view details" button in hydrator (context of where it will be used).
  - 1.3 version of the spec introduced `jumpConfig` which allows user to navigate to the stream/dataset from hydrator node configuration panel.